### PR TITLE
To make save/load compatible between dygraph and static-graph.

### DIFF
--- a/model.py
+++ b/model.py
@@ -349,8 +349,11 @@ class StaticGraphAdapter(object):
         # change inputs to the same var in cloned program
         inputs = fluid.layers.utils.map_structure(
             lambda var: prog.global_block().var(var.name), inputs)
-        # prune unraleted ops in test program, mainly for ops inserted
-        # by learning rate scheduling
+        # NOTE: When defining learning rate scheduling in static-graph, ops to
+        # increase the global step var and calculate learning rate would be
+        # prepended into _orig_prog. test program maked by `_orig_prog.clone`
+        # also would include these ops. Thus must prune these ops in test
+        # program, otherwise the global step would be changed in test.
         if self.mode != 'train':
             for op in list(prog.global_block().ops):
                 prog.global_block()._remove_op(0)

--- a/model.py
+++ b/model.py
@@ -198,10 +198,7 @@ class StaticGraphAdapter(object):
         assert param_state, "failed to load parameters, please check path"
 
         if self._executor is None:
-            # TODO: loading to CPU seems to some transform error, and only
-            # the first step get the right result
-            # executor = fluid.Executor(fluid.CPUPlace())._default_executor
-            executor = fluid.Executor(fluid.CUDAPlace(0))._default_executor
+            executor = fluid.Executor(fluid.CPUPlace())._default_executor
         else:
             executor = self._executor._default_executor
 


### PR DESCRIPTION
To make save/load compatible between dygraph and static-graph.

由于静态图和动态图save内容存在以下不一致，在load时进行转换处理：

- global step：使用learning rate schduler时
  - 动态图保存的key为"global_step" to save, 静态图保存的key为"@LR_DECAY_COUNTER@".
  - 由于global step自增时机不同，动态图在最后，静态图在最前（初始-1），动态图保存的值会比动态图多1

- global lr：未使用learning rate schduler时
  - 静态图中作为persistable var保存，动态图不保存

- accumulator name：`unique(param.name + "_" + optimizer.name+ "_" + accum_name)`
  - 静态图和动态图中optimizer.name不一致
https://github.com/PaddlePaddle/Paddle/blob/release/1.7/python/paddle/fluid/optimizer.py#L69


此外验证过程发现以下待修复问题：

- [x] 静态图eval之后的train结果错误，原因是由于learning rate schedule在ori_prog中定义，eval_prog同样clone了下来 https://github.com/PaddlePaddle/hapi/blob/master/model.py#L291
- [x] 静态图对input使用重载运算错误，原因是由于重载运算使用var的Program，但使用的var为ori_prog中的var
- [x] 静态图[load到CPU]( https://github.com/PaddlePaddle/hapi/blob/master/model.py#L200)，只有第一步计算结果正确， 原因是由于sgd等optimizer类OP的输入输出inplace和transfer一起使用时的bug，transfer back会覆盖sgd的输出。https://github.com/PaddlePaddle/Paddle/pull/22936