### PR TITLE
fix predict

### DIFF
--- a/hapi/model.py
+++ b/hapi/model.py
@@ -1622,7 +1622,7 @@ class Model(fluid.dygraph.Layer):
                 for k, v in zip(self._metrics_name(), metrics):
                     logs[k] = v
             else:
-                outs = getattr(self, mode + '_batch')(data)
+                outs = getattr(self, mode + '_batch')(data[:len(self._inputs)])
                 outputs.append(outs)
 
             logs['step'] = step


### PR DESCRIPTION
**fix predict should only take inputs data**
```
Predict begin...
Traceback (most recent call last):
  File "main.py", line 248, in <module>
    main()
  File "main.py", line 160, in main
    preds = model.predict(loader, stack_outputs=False)
  File "/usr/local/lib/python2.7/dist-packages/hapi-0.0.1-py2.7.egg/hapi/model.py", line 1529, in predict
    logs, outputs = self._run_one_epoch(test_loader, cbks, 'test')
  File "/usr/local/lib/python2.7/dist-packages/hapi-0.0.1-py2.7.egg/hapi/model.py", line 1625, in _run_one_epoch
    outs = getattr(self, mode + '_batch')(data)
  File "/usr/local/lib/python2.7/dist-packages/hapi-0.0.1-py2.7.egg/hapi/model.py", line 847, in test_batch
    return self._adapter.test_batch(inputs)
  File "/usr/local/lib/python2.7/dist-packages/hapi-0.0.1-py2.7.egg/hapi/model.py", line 126, in test_batch
    return self._run(inputs, None)
  File "/usr/local/lib/python2.7/dist-packages/hapi-0.0.1-py2.7.egg/hapi/model.py", line 276, in _run
    + " does not match number of arguments of `forward` method"
AssertionError: number of inputs does not match number of arguments of `forward` method
```